### PR TITLE
fix: remove sudo from chsh command

### DIFF
--- a/scripts/self/install
+++ b/scripts/self/install
@@ -31,7 +31,7 @@ touch "$HOME/.z"
 
 if ! str::contains zsh "$SHELL"; then
 	output::answer "Setting zsh as the default shell"
-	sudo chsh -s "$(command -v zsh)" | log::file "Setting zsh as default shell"
+	chsh -s "$(command -v zsh)" | log::file "Setting zsh as default shell"
 fi
 
 output::answer "Installing Zim"


### PR DESCRIPTION
if you use sudo with chsh changes default shell for root user, not for the current user